### PR TITLE
Fix Title Font Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ workflows:
 We welcome [issues](https://github.com/CircleCI-Public/php-orb/issues) to and [pull requests](https://github.com/CircleCI-Public/php-orb/pulls) against this repository!
 For further questions/comments about this or other orbs, visit the Orb Category of [CircleCI Discuss](https://discuss.circleci.com/c/orbs).
 
-### Publishing
+## Publishing
 
 New versions of this orb are published by pushing a SemVer git tag by the Community & Partner Engineering Team.
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
The **Publishing** title font size in README is smaller than other title.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
Fix the **Publishing** title to properly sized as same as other title in README.

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
