### PR TITLE
[semver:patch] fix: Make Install Composer step to honor `--install-dir` composer argument

### DIFF
--- a/src/commands/install-composer.yml
+++ b/src/commands/install-composer.yml
@@ -12,4 +12,4 @@ steps:
       name: Install Composer
       command: |
         curl -sS https://getcomposer.org/installer -o composer-setup.php
-        sudo php composer-setup.php --filename=composer <<parameters.install-dir>>
+        sudo php composer-setup.php --filename=composer --install-dir=<<parameters.install-dir>>


### PR DESCRIPTION
Currently `install-dir` parameter is not used by composer at all and it is installed into the current path (`pwd`).

See my logs:
![image](https://user-images.githubusercontent.com/1862580/84986078-3300ca80-b13e-11ea-9659-c312cd4cf7a9.png)

This will probably fix it. (See description of `--install-dir` composer argument on https://getcomposer.org/download/ .)