### PR TITLE
[semver:minor] Composer install version

### DIFF
--- a/src/commands/install-composer.yml
+++ b/src/commands/install-composer.yml
@@ -14,7 +14,7 @@ parameters:
 
 steps:
   - run:
-      name: Download Composer
+      name: Install Composer
       command: |
         curl -sS https://getcomposer.org/installer -o composer-setup.php
         sudo php composer-setup.php --filename=composer --install-dir=<<parameters.install-dir>> <<#parameters.install-version>>--version=<<parameters.install-version>><</parameters.install-version>>

--- a/src/commands/install-composer.yml
+++ b/src/commands/install-composer.yml
@@ -6,10 +6,26 @@ parameters:
     default:  /usr/local/bin
     description: |
       By default, composer will be installed at "/usr/local/bin/composer", use this to override the install directory.
+  install-version:
+    type: string
+    default: ''
+    description: |
+      By default, composer will install the latest composer version, use this to override the installed version.
 
 steps:
   - run:
-      name: Install Composer
-      command: |
-        curl -sS https://getcomposer.org/installer -o composer-setup.php
-        sudo php composer-setup.php --filename=composer --install-dir=<<parameters.install-dir>>
+      name: Download Composer
+      command: curl -sS https://getcomposer.org/installer -o composer-setup.php
+  - when:
+      condition: <<parameters.install-version>>
+      steps:
+        - run:
+            name: Install Composer (<<parameters.install-version>>)
+            command: sudo php composer-setup.php --filename=composer --version=<<parameters.install-version>> --install-dir=<<parameters.install-dir>>
+  - when:
+      condition:
+        not: <<parameters.install-version>>
+      steps:
+        - run:
+            name: Install Composer (latest)
+            command: sudo php composer-setup.php --filename=composer --install-dir=<<parameters.install-dir>>

--- a/src/commands/install-composer.yml
+++ b/src/commands/install-composer.yml
@@ -15,17 +15,6 @@ parameters:
 steps:
   - run:
       name: Download Composer
-      command: curl -sS https://getcomposer.org/installer -o composer-setup.php
-  - when:
-      condition: <<parameters.install-version>>
-      steps:
-        - run:
-            name: Install Composer (<<parameters.install-version>>)
-            command: sudo php composer-setup.php --filename=composer --version=<<parameters.install-version>> --install-dir=<<parameters.install-dir>>
-  - when:
-      condition:
-        not: <<parameters.install-version>>
-      steps:
-        - run:
-            name: Install Composer (latest)
-            command: sudo php composer-setup.php --filename=composer --install-dir=<<parameters.install-dir>>
+      command: |
+        curl -sS https://getcomposer.org/installer -o composer-setup.php
+        sudo php composer-setup.php --filename=composer --install-dir=<<parameters.install-dir>> <<#parameters.install-version>>--version=<<parameters.install-version>><</parameters.install-version>>

--- a/src/examples/install_composer_packages.yml
+++ b/src/examples/install_composer_packages.yml
@@ -10,7 +10,8 @@ usage:
       executor: php/default
       steps:
         - checkout
-        - php/install-composer
+        - php/install-composer:
+            install-version: '1.10.16'
         - php/install-packages
   workflows:
     install:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Due to composer releasing 2.0 as the stable release, any PHP projects that have composer plugin using V1 of the API are erroring out. Which drives this need of needing a way to define a composer install version parameter.

### Description

Based on how `composer-setup.php` was developed. The `--version` definition needs to be based on a semantic version spec. I had to use a `when` condition to determine if the composer `install-version` parameter was defined or not, as passing in an empty string or boolean values are not supported.
