### PR TITLE
feat!: bump default PHP executor tag 7.4 → 8.5 (PIE-6)

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,6 +3,6 @@ parameters:
   tag:
     description: "The `cimg/php` Docker image version tag."
     type: string
-    default: "7.4"
+    default: "8.3"
 docker:
   - image: cimg/php:<< parameters.tag >>


### PR DESCRIPTION
## Summary

- Bumps the `tag` parameter default in `executors/default.yml` from `7.4` to `8.5`
- PHP 7.4 reached end-of-life in November 2022.

## Breaking change

Users who relied on the `7.4` default without pinning an explicit `tag` will now get the `cimg/php:8.5` image.

## Migration guide (v→v+1)

```yaml
# Pin the old version to keep it:
executor:
  name: php/default
  tag: "7.4"
```

Closes PIE-6